### PR TITLE
Fix click handling for AnkiMobile

### DIFF
--- a/click_word/front.html
+++ b/click_word/front.html
@@ -54,7 +54,7 @@
 
     function updateWordBank() {
       words.sort(() => Math.random() - 0.5);
-      wordsContainer.innerHTML = words.map(word => `<span class="word">${word}</span>`).join('');
+      wordsContainer.innerHTML = words.map(word => `<span class="word tappable">${word}</span>`).join('');
     }
 
     function handleWordClick(event) {

--- a/match_pairs/front.html
+++ b/match_pairs/front.html
@@ -60,7 +60,7 @@
     function createHorizontalWord(word) {
       const wordElement = document.createElement('span');
       wordElement.innerHTML = word;
-      wordElement.className = 'horizontal-word';
+      wordElement.className = 'horizontal-word tappable';
       wordElement.draggable = true;
       wordElement.addEventListener('dragstart', drag);
       wordElement.addEventListener('click', () => matchWord(word, wordElement));


### PR DESCRIPTION
AnkiMobile moves to the card's back when an element is clicked unless the element has an onclick listener or the `tappable` class.

Adds the `tappable` class to Match Pairs horizontal words and Click Word words.