### PR TITLE
Fix for dragging images

### DIFF
--- a/match_pairs/front.html
+++ b/match_pairs/front.html
@@ -104,6 +104,9 @@
       createWordElement(word, isHorizontal = false) {
         const element = document.createElement(isHorizontal ? 'span' : 'div');
         element.innerHTML = word;
+        element.querySelectorAll("img").forEach((img) => {
+          img.setAttribute("draggable", "false");
+        });
         element.className = isHorizontal ? 'horizontal-word' : 'word';
 
         if (isHorizontal) {


### PR DESCRIPTION
Since images are draggable by default, dragging an image inside of a horizontal-word causes the image itself to be dragged rather than the horizontal-word.

Added the `draggable="false"` attribute to images inside of draggable sections to allow them to drag correctly.